### PR TITLE
Remove dependencies and handle user not found

### DIFF
--- a/manage.js
+++ b/manage.js
@@ -1,7 +1,6 @@
 #! /usr/bin/env node
 
-const fetch = require("node-fetch");
-const fs = require("fs-extra");
+const fs = require("fs");
 const readline = require("readline");
 const { spawn } = require("child_process");
 
@@ -27,6 +26,12 @@ async function buildProjectList() {
   let page = await fetch(
     `${GLITCH_API}/v1/users/by/login/projects?limit=100&login=${user}`
   ).then((r) => r.json());
+
+  if (!page.items || !page.items.length) {
+    console.log(`No projects found for user '${user}'`);
+    process.exit(1);
+  }
+
   projects.push(...page.items.map((project) => project.domain));
   while (page.hasMore) {
     console.log("fetching more projects...");
@@ -38,7 +43,7 @@ async function buildProjectList() {
 
 async function init() {
   if (fs.existsSync(CACHE_PATH)) {
-    dataCache = JSON.parse(fs.readFileSync(CACHE_PATH).toString("utf-8"));
+    dataCache = JSON.parse(fs.readFileSync(CACHE_PATH, "utf-8"));
   }
 
   switch (command) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,61 +1,18 @@
 {
   "name": "@potch/glitch-project-export",
-  "version": "1.0.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@potch/glitch-project-export",
-      "version": "1.0.2",
+      "version": "1.2.3",
       "license": "ISC",
-      "dependencies": {
-        "fs-extra": "^8.1.0",
-        "node-fetch": "^2.6.0"
-      },
       "bin": {
         "glitch-project-export": "manage.js"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
-    },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=18"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "homepage": "https://github.com/potch/glitch-project-export",
   "author": "Potch",
   "license": "ISC",
-  "dependencies": {
-    "fs-extra": "^8.1.0",
-    "node-fetch": "^2.6.0"
+  "engines": {
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
Closes https://github.com/potch/glitch-project-export/issues/4 with two improvements:
1. Remove node-fetch and fs-extra. Neither is really necessary, except node-fetch is useful for old Node versions < 17. I'd be fine removing that change from the PR to preserve further backwards functionality, but the downside is a punycode warning for everyone else.
2. Handles a crash when a username doesn't exist:
   ```
   TypeError: Cannot read properties of undefined (reading 'map')
       at buildProjectList (/usr/lib/node_modules/@potch/glitch-project-export/manage.js:30:31)
       at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
       at async list (/usr/lib/node_modules/@potch/glitch-project-export/manage.js:116:18)
   ```

I tested this with happy and sad paths for users existing, not existing, and having no projects (user 'fff' exists but has no projects), then exporting projects for a user.